### PR TITLE
[1.2.3] Add .gem_rbs_collection/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ mkmf.log
 # rspec failure tracking
 .rspec_status
 *.gem
+
+# RBS collection
+.gem_rbs_collection/


### PR DESCRIPTION
Prevents the RBS collection directory from being tracked by git.